### PR TITLE
Add index exports for lib modules

### DIFF
--- a/src/lib/bono/index.ts
+++ b/src/lib/bono/index.ts
@@ -1,0 +1,4 @@
+export * from './bonoUtils';
+export * from './exportUtils';
+export * from './graciaUtils';
+export * from './validationUtils';

--- a/src/lib/calculations/index.ts
+++ b/src/lib/calculations/index.ts
@@ -1,0 +1,5 @@
+export * from './francesMetod';
+export * from './indicadoresBono';
+export * from './newtonRaphsonUtils';
+export * from './precioBonoCalculator';
+export * from './tceaCalculator';

--- a/src/lib/firebase/index.ts
+++ b/src/lib/firebase/index.ts
@@ -1,0 +1,5 @@
+export * from './adminUtils';
+export * from './errorMessages';
+export * from './firebase';
+export * from './useCurrentUser';
+export * from './userUtils';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,5 @@
+export * from './utils';
+
+export * from './bono';
+export * from './calculations';
+export * from './firebase';


### PR DESCRIPTION
## Summary
- centralize lib exports with `src/lib/index.ts`
- add submodule index files for bono, calculations and firebase

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867ed5fe9b88327be5e0b240d711c90